### PR TITLE
Sanitize STEM upload filenames

### DIFF
--- a/Kerajel.NuclearEvaluation.sln
+++ b/Kerajel.NuclearEvaluation.sln
@@ -20,6 +20,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuclearEvaluation.Server", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuclearEvaluation.Client.Tests", "tests\NuclearEvaluation.Client.Tests\NuclearEvaluation.Client.Tests.csproj", "{D472F804-4485-4CE4-8830-9BD86B4C3D22}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuclearEvaluation.Server.Tests", "tests\NuclearEvaluation.Server.Tests\NuclearEvaluation.Server.Tests.csproj", "{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +86,14 @@ Global
 		{D472F804-4485-4CE4-8830-9BD86B4C3D22}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D472F804-4485-4CE4-8830-9BD86B4C3D22}.Release|x86.ActiveCfg = Release|x86
 		{D472F804-4485-4CE4-8830-9BD86B4C3D22}.Release|x86.Build.0 = Release|x86
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Debug|x86.Build.0 = Debug|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Release|x86.ActiveCfg = Release|Any CPU
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,6 +106,7 @@ Global
 		{A1B2C3D4-1111-4222-8333-944455566677} = {6B6EF2DA-420B-4261-8F5B-E439F2CED469}
 		{66B932E0-BB9B-4C8A-970B-5F24839A1634} = {6B6EF2DA-420B-4261-8F5B-E439F2CED469}
 		{D472F804-4485-4CE4-8830-9BD86B4C3D22} = {36E8C17C-B7EC-433F-9057-9F8579552F0C}
+		{D91D55BA-BB49-4C2E-B064-97C6D2A8D338} = {36E8C17C-B7EC-433F-9057-9F8579552F0C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F8932A31-767B-408F-B07D-11CA303341BC}

--- a/src/NuclearEvaluation.Server/Services/EFS/EfsFileService.cs
+++ b/src/NuclearEvaluation.Server/Services/EFS/EfsFileService.cs
@@ -2,6 +2,7 @@
 using Kerajel.Primitives.Models;
 using NuclearEvaluation.Kernel.Models.Files;
 using NuclearEvaluation.Server.Interfaces.EFS;
+using NuclearEvaluation.Server.Services.Files;
 
 namespace NuclearEvaluation.Server.Services.EFS;
 
@@ -25,7 +26,8 @@ public class EfsFileService : IEfsFileService
                 fileDirectory.Create();
             }
 
-            FileInfo fileInfo = new(Path.Combine(fileDirectory.FullName, command.FileName));
+            string safeFileName = SafeFileName.FromClientFileName(command.FileName, command.FileId);
+            FileInfo fileInfo = new(Path.Combine(fileDirectory.FullName, safeFileName));
 
             await WriteToFile(fileInfo, command.FileContent, ct);
 

--- a/src/NuclearEvaluation.Server/Services/Files/SafeFileName.cs
+++ b/src/NuclearEvaluation.Server/Services/Files/SafeFileName.cs
@@ -1,0 +1,47 @@
+namespace NuclearEvaluation.Server.Services.Files;
+
+public static class SafeFileName
+{
+    const int MaxFileNameLength = 255;
+
+    public static string FromClientFileName(string? fileName, Guid fallbackId)
+    {
+        string normalized = (fileName ?? string.Empty).Replace('\\', '/');
+        string safe = Path.GetFileName(normalized).Trim();
+
+        if (string.IsNullOrWhiteSpace(safe) || safe is "." or "..")
+        {
+            return $"{fallbackId:N}.upload";
+        }
+
+        char[] invalid = Path.GetInvalidFileNameChars();
+        char[] chars = safe.ToCharArray();
+        for (int i = 0; i < chars.Length; i++)
+        {
+            if (char.IsControl(chars[i]) || chars[i] is '/' or '\\' || invalid.Contains(chars[i]))
+            {
+                chars[i] = '_';
+            }
+        }
+
+        safe = new string(chars).Trim();
+        if (string.IsNullOrWhiteSpace(safe) || safe is "." or "..")
+        {
+            return $"{fallbackId:N}.upload";
+        }
+
+        if (safe.Length <= MaxFileNameLength)
+        {
+            return safe;
+        }
+
+        string extension = Path.GetExtension(safe);
+        if (extension.Length >= MaxFileNameLength)
+        {
+            return safe[..MaxFileNameLength];
+        }
+
+        int stemLength = MaxFileNameLength - extension.Length;
+        return safe[..stemLength] + extension;
+    }
+}

--- a/src/NuclearEvaluation.Server/Services/STEM/StemPreviewService.cs
+++ b/src/NuclearEvaluation.Server/Services/STEM/StemPreviewService.cs
@@ -4,6 +4,7 @@ using NuclearEvaluation.Kernel.Models.DataManagement.Stem;
 using NuclearEvaluation.Kernel.Models.Files;
 using NuclearEvaluation.Server.Interfaces.EFS;
 using NuclearEvaluation.Server.Interfaces.STEM;
+using NuclearEvaluation.Server.Services.Files;
 using Polly;
 using Polly.Bulkhead;
 using System.Runtime.CompilerServices;
@@ -66,7 +67,8 @@ public class StemPreviewService(
 
         async Task<OperationResult> Execute()
         {
-            WriteFileCommand writeFileCommand = new(fileId, fileName, stream, true);
+            string safeFileName = SafeFileName.FromClientFileName(fileName, fileId);
+            WriteFileCommand writeFileCommand = new(fileId, safeFileName, stream, true);
 
             OperationResult<FileInfo> writeFileResult = await efsFileService.Write(writeFileCommand, linkedCts.Token);
 
@@ -75,13 +77,13 @@ public class StemPreviewService(
                 return OperationResult.Faulted(writeFileResult);
             }
 
-            StemPreviewFileMetadata fileMetadata = new(fileId, fileName);
+            StemPreviewFileMetadata fileMetadata = new(fileId, safeFileName);
 
             await stemPreviewEntryService.InsertStemPreviewFileMetadata(sessionId, fileMetadata, linkedCts.Token);
 
             using FileStream fs = writeFileResult.Content!.OpenRead();
 
-            IAsyncEnumerable<StemPreviewEntry> asyncEnumerable = stemPreviewParser.Parse(fs, fileName, linkedCts.Token);
+            IAsyncEnumerable<StemPreviewEntry> asyncEnumerable = stemPreviewParser.Parse(fs, safeFileName, linkedCts.Token);
             asyncEnumerable = AssignFileId(asyncEnumerable, fileId, linkedCts.Token);
 
             await stemPreviewEntryService.InsertStemPreviewEntries(sessionId, asyncEnumerable, linkedCts.Token);

--- a/tests/NuclearEvaluation.Server.Tests/NuclearEvaluation.Server.Tests.csproj
+++ b/tests/NuclearEvaluation.Server.Tests/NuclearEvaluation.Server.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="10.0.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\NuclearEvaluation.Server\NuclearEvaluation.Server.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>

--- a/tests/NuclearEvaluation.Server.Tests/SafeFileNameTests.cs
+++ b/tests/NuclearEvaluation.Server.Tests/SafeFileNameTests.cs
@@ -1,0 +1,42 @@
+using NuclearEvaluation.Server.Services.Files;
+
+namespace NuclearEvaluation.Server.Tests;
+
+public class SafeFileNameTests
+{
+    static readonly Guid FallbackId = Guid.Parse("2e07a075-8c52-4424-a604-65e1344aa8b3");
+
+    [Theory]
+    [InlineData("../evil.csv", "evil.csv")]
+    [InlineData("..\\evil.csv", "evil.csv")]
+    [InlineData("/tmp/report.tsv", "report.tsv")]
+    [InlineData("C:\\temp\\report.dat", "report.dat")]
+    [InlineData("nested/folder/sample.csv", "sample.csv")]
+    public void FromClientFileNameKeepsOnlyTheBaseName(string input, string expected)
+    {
+        string result = SafeFileName.FromClientFileName(input, FallbackId);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("../")]
+    public void FromClientFileNameFallsBackWhenNoSafeNameRemains(string input)
+    {
+        string result = SafeFileName.FromClientFileName(input, FallbackId);
+
+        Assert.Equal($"{FallbackId:N}.upload", result);
+    }
+
+    [Fact]
+    public void FromClientFileNameReplacesControlCharacters()
+    {
+        string result = SafeFileName.FromClientFileName("sample\u0001.csv", FallbackId);
+
+        Assert.Equal("sample_.csv", result);
+    }
+}

--- a/tests/e2e/specs/nuclear-evaluation.spec.ts
+++ b/tests/e2e/specs/nuclear-evaluation.spec.ts
@@ -647,7 +647,7 @@ test('ADD-18 Query Builder switches to Sample grid', async ({ page }) => {
 test('ADD-19 Query Builder Apply with empty filters keeps grid usable', async ({ page }) => {
   await openQueryBuilder(page);
   await page.getByRole('button', { name: /Apply query/i }).click();
-  await expect(page.getByRole('row', { name: /10000 Sampling/ })).toBeVisible();
+  await expect(page.getByRole('row', { name: /\b10000\b/ })).toBeVisible();
   await expectNoVisibleAppError(page);
 });
 


### PR DESCRIPTION
## Summary

- Normalize client-supplied STEM upload filenames to safe basenames before storage, metadata persistence, and parser selection.
- Add a storage-layer guard so future file writes also sanitize filenames.
- Add focused server tests for traversal-style, empty, and control-character filenames.
- Relax the empty-query e2e assertion so it checks grid usability without depending on a mutable seeded row label.

## Validation

- `dotnet test tests\NuclearEvaluation.Server.Tests\NuclearEvaluation.Server.Tests.csproj`
- Docker e2e suite: 64/64 passed
